### PR TITLE
Added dkms build infra

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+obj-m := focal_spi.o
+
+all:
+	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+
+clean:
+	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
+
+install:
+	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules_install
+
+uninstall:
+	rm /lib/modules/$(shell uname -r)/extra/focal_spi.ko
+	depmod
+

--- a/README.md
+++ b/README.md
@@ -1,98 +1,30 @@
-build kernel driver:
+build kernel driver using dkms:
 
-Step 1:
-get Linux kernel source code ,if you have kernel source code,ignore this.
-
-open Software&Update->Ubuntu software,enable "Source code" label
-
-```bash
-uname -a
-Linux test-KVADRA-LE14U 6.5.13 #2 SMP PREEMPT_DYNAMIC Mon Jun 17 15:45:27 CST 2024 x86_64 x86_64 x86_64 GNU/Linux
-```
-
-```bash
-#22.04
-sudo apt-get source linux-source-6.5.0
-
-#24.04
-sudo chown _apt /var/lib/update-notifier/package-data-downloads/partial/
-sudo chown -Rv _apt:root /var/lib/apt/lists
-sudo apt-get source linux-source-6.8.0
-```
-
-install  binutils toolchain
+### Step 1: Dependencies
 
 ```bash
 sudo apt-get update
-sudo apt-get install libncurses5-dev 
-sudo apt-get install build-essential openssl
-sudo apt-get install flex
-sudo apt-get install bison
-sudo apt-get install openssl
-sudo apt-get install libssl-dev
-sudo apt-get install libelf-dev
+sudo apt-get install build-essential dkms
 ```
 
-Step 2:
-copy focal_spi.c to /usr/src/linux-source-6.5.0/drivers/input/touchscreen/
+## Step 2: Install via dkms
 
-```bash
-cd /usr/src/linux-source-6.5.0/drivers/input/touchscreen/
+```
+sudo dpms add .
+sudo dkms add .
+sudo dkms build focal_spi/1.0
+sudo dkms install focal_spi/1.0
 ```
 
-change Makefile,add nearby "obj-$(CONFIG_TOUCHSCREEN_SURFACE3_SPI)  += surface3_spi.o
+## Step 3: Verify it worked
 
-```bash
-obj-$(CONFIG_TOUCHSCREEN_FOCAL_SPI)     += focal_spi.o
+```
+sudo dmesg | grep focal
+...
+ls -l /dev/focal_moh_spi
 ```
 
-change Kconfig,add nearby "config TOUCHSCREEN_SURFACE3_SPI"
-
-```bash
-config TOUCHSCREEN_FOCAL_SPI
-           tristate "Focaltech fingerprint SPI "
-        depends on SPI
-        depends on GPIOLIB || COMPILE_TEST
-        help
-          Say Y here if you have the Focaltech SPI fingerprint
-          controller chip as found on the PC in your system.
-
-          If unsure, say N.
-
-          To compile this driver as a module, choose M here: the
-          module will be called focal_spi.
-```
-
-Step 3:
-build and install kernel
-
-choice Focaltech fingerprint SPI  (TOUCHSCREEN_FOCAL_SPI) [N/m/y/?] (NEW)  m
-
-```bash
-#22.04
-cd /usr/src/linux-source-6.5.0
-sudo cp /boot/config-6.5.0-35-generic .config
-sudo make -j10
-sudo make modules 
-sudo make modules_install
-sudo make install
-```
-
-```bash
-#24.04
-sudo chown root:root linux-source-6.8.0/ -R
-sudo chmod 777 linux-source-6.8.0/ -R
-cd /usr/src/linux-source-6.8.0
-sudo cp /boot/config-6.8.0-31-generic .config
-sudo make -j10
-sudo make modules 
-sudo make modules_install
-sudo make install
-```
-
-restart,then you can see a device as "/dev/focal_moh_spi"
-
-Install deb 
+## Step 4: Install modified libfprint
 
 ```bash
 #22.04
@@ -101,7 +33,6 @@ dpkg -i libfprint-2-2_1.94.4+tod1-0ubuntu1~22.04.2_spi_amd64_20240620.deb
 #24.04
 dpkg -i --force-overwrite libfprint-2-2_1.94.4+tod1-0ubuntu1~22.04.2_spi_amd64_20240620.deb
 ```
-
 
 
 Notice:

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,0 +1,7 @@
+PACKAGE_NAME="focal_spi"
+PACKAGE_VERSION="1.0.3"
+CLEAN="make clean"
+MAKE="make all"
+BUILT_MODULE_NAME[0]="focal_spi"
+DEST_MODULE_LOCATION[0]="/extra"
+AUTOINSTALL="yes"


### PR DESCRIPTION
dkms is a better way to build out-of-tree kernel modules.

It is much easier to use for end users.

I can't be 100% sure it worked or if this is an issue with my reader but I get:

```
[100772.535239] focal focal_fp_driver_init is called,driver version is v1.0.3
[100772.535353] focal focal_spi_probe enter
[100772.535449] focalfp-spi spi-FTE6600:00: Failed to get power GPIO 0: -2
[100772.535499] focalfp-spi: probe of spi-FTE6600:00 failed with error -2
```